### PR TITLE
Revert "Increase max size of a message to 1MB. Fixes #24"

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
               
         private const int BatchSize = 100;
 
-        // Suggested to use 1008k instead of 1024k to leave padding room for headers.
-        private const int MaxByteSize = 1008 * 1024; 
+        // Suggested to use 240k instead of 256k to leave padding room for headers.
+        private const int MaxByteSize = 240 * 1024; 
         
         /// <summary>
         /// Create a sender around the given client. 

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubAsyncCollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubAsyncCollectorTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         {
             var collector = new TestEventHubAsyncCollector();
 
-            // Trip the 1024k EventHub limit.
+            // Trip the 256k EventHub limit.
             for (int i = 0; i < 10; i++)
             {
                 var e1 = new EventData(new byte[10 * 1024]);
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.Empty(collector.SentEvents);
 
             // This will push it over the theshold
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 20; i++)
             {
                 var e1 = new EventData(new byte[10 * 1024]);
                 await collector.AddAsync(e1);
@@ -120,8 +120,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         {
             var collector = new TestEventHubAsyncCollector();
 
-            // event hub max is 1024k payload.
-            var hugePayload = new byte[1100 * 1024];
+            // event hub max is 256k payload.
+            var hugePayload = new byte[300 * 1024];
             var e1 = new EventData(hugePayload);
 
             try


### PR DESCRIPTION
This reverts commit b4f45ddea9c414626894dee9346f338cd4e2d561.

After testing in production it turned out different tiers have different max message sizes.
standard: 1MB
basic: 256KB

We need to stick with 256KB for now. Also there is no way to get pricing tier for an Event Hub using SDK. They have a missing docs tracking:
https://github.com/MicrosoftDocs/azure-docs/issues/38643