### PR TITLE
Add optional parameter to not checkpoint failed job executions.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
@@ -36,5 +36,11 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub receiver.
         /// </summary>
         public string Connection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional setting to checkpoint on failures. If true (default), it will always checkpoint processed messages, even on exceptions.
+        /// If false, it will not checkpoint messages if uncaught exceptions occurred.
+        /// </summary>
+        public bool CheckpointOnFailure { get; set; } = true;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             string consumerGroup = attribute.ConsumerGroup ?? PartitionReceiver.DefaultConsumerGroupName;
             string resolvedConsumerGroup = _nameResolver.ResolveWholeString(consumerGroup);
+            bool checkpointOnFailure = attribute.CheckpointOnFailure;
 
             string connectionString = null;
             if (!string.IsNullOrWhiteSpace(attribute.Connection))
@@ -84,6 +85,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                                                 eventHostListener,
                                                 singleDispatch,
                                                 _options.Value,
+                                                checkpointOnFailure,
                                                 _logger);
                  return Task.FromResult(listener);
              };

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             loggerMock.Setup(l => l.BeginScope(It.IsAny<object>())).Returns(new NoopLoggerScope());
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, true, checkpointer.Object);
 
             for (int i = 0; i < 100; i++)
             {
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             loggerMock.Setup(l => l.BeginScope(It.IsAny<object>())).Returns(new NoopLoggerScope());
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, false, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, false, true, checkpointer.Object);
 
             for (int i = 0; i < 100; i++)
             {
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>(MockBehavior.Strict);
             loggerMock.Setup(l => l.BeginScope(It.IsAny<object>())).Returns(new NoopLoggerScope());
 
-            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, true, checkpointer.Object);
 
             await eventProcessor.ProcessEventsAsync(partitionContext, events);
 
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var checkpointer = new Mock<EventHubListener.ICheckpointer>(MockBehavior.Strict);
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var loggerMock = new Mock<ILogger>(MockBehavior.Strict);
-            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, true, checkpointer.Object);
 
             await eventProcessor.CloseAsync(partitionContext, CloseReason.Shutdown);
 
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var checkpointer = new Mock<EventHubListener.ICheckpointer>(MockBehavior.Strict);
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
-            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, testLogger, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, testLogger, true, true, checkpointer.Object);
 
             var ex = new InvalidOperationException("My InvalidOperationException!");
 
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var checkpointer = new Mock<EventHubListener.ICheckpointer>(MockBehavior.Strict);
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
-            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, testLogger, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, testLogger, true, true, checkpointer.Object);
 
             // ctor is private
             var constructor = typeof(ReceiverDisconnectedException)
@@ -213,6 +213,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                                     null,
                                     false,
                                     new EventHubOptions(),
+                                    true,
                                     testLogger,
                                     new Mock<CloudBlobContainer>(MockBehavior.Strict, new Uri("https://eventhubsteststorageaccount.blob.core.windows.net/azure-webjobs-eventhub")).Object);
 


### PR DESCRIPTION
Until now, the default behaviour was to always checkpoint all received messages, regardless of success. The rationale for this is to make sure that the eventhub does not block, and the function is responsible for handling exceptions.

However, there are use cases where this is not required behaviour.
- In some cases order needs to be guaranteed. If the function is responsible for putting failed events in a poison queue, then this will break the order guarantee. It will continue processing new events, and can't process the poisoned event later (due to order contraints). If the function blocks on the failed message, it will keep the order guarantees.
- The code that puts a failed event in a poison queue can fail as well. If this happens, the data is lost in the current situation. With a non-checkpointing function it will keep the event in the queue until it is processed correctly.

In this PR, we'll add the additional parameter 'CheckpointOnFailure'. If this parameter is set to True (the default value) it will checkpoint all events, regardless of success or failure. If this parameter is False, it will not checkpoint events that caused exceptions.