### PR TITLE
Read trace context from application or system properties

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
@@ -315,13 +315,15 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             {
                 link = null;
 
-                if (!message.Properties.ContainsKey("Diagnostic-Id"))
+                if ((message.SystemProperties.TryGetValue("Diagnostic-Id", out var diagnosticIdObj) || message.Properties.TryGetValue("Diagnostic-Id", out diagnosticIdObj)) 
+                    && diagnosticIdObj is string diagnosticIdString)
                 {
-                    return false;
+                    link = new Activity("Microsoft.Azure.EventHubs.Process");
+                    link.SetParentId(diagnosticIdString);
+                    return true;
                 }
 
-                link = message.ExtractActivity();
-                return true;
+                return false;
             }
         }
     }


### PR DESCRIPTION
Message brokers can put trace-context into SystemProperties. This is what IoT Hub does. 

We should expect Diagnostic-Id in SystemProperties and if there is nothing there, check Application properties.
