### PR TITLE
Calculate approx time in queue for EventHubs messages and populate EventHub info

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInput.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInput.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             return this.Events[this._selector];
         }
 
-        public Dictionary<string, string> GetTriggerDetails(PartitionContext context)
+        public Dictionary<string, string> GetTriggerDetails(PartitionContext context, string endpoint)
         {
             if (Events.Length == 0)
             {
@@ -84,7 +84,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 { "Offset", offset },
                 { "EnqueueTimeUtc", enqueueTimeUtc },
                 { "SequenceNumber", sequenceNumber },
-                { "Count", Events.Length.ToString()}
+                { "Count", Events.Length.ToString()},
+                { "Endpoint", endpoint},
+                { "Entity", context.EventHubPath},
             };
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var checkpointer = new Mock<EventHubListener.ICheckpointer>(MockBehavior.Strict);
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
-            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, testLogger, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options,  executor.Object, testLogger, true, checkpointer.Object);
 
             var ex = new InvalidOperationException("My InvalidOperationException!");
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/WebJobs.Extensions.EventHubs.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/WebJobs.Extensions.EventHubs.Tests.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.14" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.14" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.18-11717" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.18-11717" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This change enables custom metrics on time in queue for EventHubs messages and populates EventHub info on trigger request telemetry (this will allow to show AppMap properly and navigate to EventHub resource from AI views.

Please advise 

1. Is populating EventHub info on trigger details is a good idea
**Pros**:  all loggers can benefit from it
**Cons**: no other triggers do it at least as of today and likely it's the same on all executions

Is there a better place?

2. Extension already populates enqueued time in TriggerDetails, but for batches it populate time from 2 messages, while in AppInsights we really want all/average, so I propagate it within `Activity`, i.e. we have 2 different ways at the same time.

Can I change trigger details (e.g. send all enqueued times separated by comma)? Populate average? 

This relies on https://github.com/Azure/azure-webjobs-sdk/pull/2428 changes in webjobs to populate data on AppInsights telemetry. 

