### PR TITLE
Increasing max message size and batch size. Fixes #29

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
     /// <summary>
     /// Core object to send events to EventHub. 
     /// Any user parameter that sends EventHub events will eventually get bound to this object. 
-    /// This will queue events and send in batches, also keeping under the 256kb event hub limit per batch. 
+    /// This will queue events and send in batches, also keeping under the 1024kb event hub limit per batch. 
     /// </summary>
     internal class EventHubAsyncCollector : IAsyncCollector<EventData>
     {
@@ -25,8 +25,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
               
         private const int BatchSize = 100;
 
-        // Suggested to use 240k instead of 256k to leave padding room for headers.
-        private const int MaxByteSize = 240 * 1024;
+        // Suggested to use 1008k instead of 1024k to leave padding room for headers.
+        private const int MaxByteSize = 1008 * 1024;
 
         private readonly ILogger _logger;
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.EventHubs</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.EventHubs</PackageId>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <Authors>Microsoft</Authors>

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubAsyncCollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubAsyncCollectorTests.cs
@@ -95,8 +95,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         {
             var collector = new TestEventHubAsyncCollector();
 
-            // Trip the 256k EventHub limit.
-            for (int i = 0; i < 10; i++)
+            // Trip the 1024k EventHub limit.
+            for (int i = 0; i < 50; i++)
             {
                 var e1 = new EventData(new byte[10 * 1024]);
                 await collector.AddAsync(e1);
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.Empty(collector.SentEvents);
 
             // This will push it over the theshold
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < 60; i++)
             {
                 var e1 = new EventData(new byte[10 * 1024]);
                 await collector.AddAsync(e1);
@@ -120,8 +120,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         {
             var collector = new TestEventHubAsyncCollector();
 
-            // event hub max is 256k payload.
-            var hugePayload = new byte[300 * 1024];
+            // event hub max is 1024k payload.
+            var hugePayload = new byte[1200 * 1024];
             var e1 = new EventData(hugePayload);
 
             try


### PR DESCRIPTION
#29 cab be fixed by increasing max message size. If the message size is exceeded for basic(256KB) or standard(1024KB) EH SDK will throw an exception on send message in `EventHubAsyncCollector`
